### PR TITLE
Link to official documentation for version 3.24.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ js_of_ocaml -o example.js +gen_js_api/ojs_runtime.js example.byte
 
 ### Documentation and conventions used :
 You can find the official documentation:
-https://developers.google.com/maps/documentation/javascript/reference
+https://developers.google.com/maps/documentation/javascript/3.24/reference
 
 The conventions used are ```gen_js_api``` 's :
 


### PR DESCRIPTION
As it's the binding for the version 3.24, we must redirect to the API of this version. The link was for the last release version (which is 3.25 since August, 17 2016).
