### PR TITLE
Fix Geocoder.geocode

### DIFF
--- a/googlemaps.mli
+++ b/googlemaps.mli
@@ -1479,7 +1479,7 @@ module Geocoder: sig
   val new_geocoder : unit -> t [@@js.new]
   val geocode :
     t -> GeocoderRequest.t ->
-    (GeocoderResult.t list -> geocoder_status -> unit) ->
+    (GeocoderResult.t list option -> geocoder_status -> unit) ->
     unit [@@js.call]
 end
 [@js.scope "google.maps"]


### PR DESCRIPTION
The callback receives a null argument in case of error.
There are probably other places where a similar change needs to be performed...