### PR TITLE
adding the 'MarkerClusterer' module into the '2.4' version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ opam install ocaml-googlemaps
 A minimal example can be found in the folder example.
 You only need to type ```make``` in the ```example``` folder to get ```example.js```, open ```index.html``` to see the result
 
-### Compilation : 
+### Compilation :
 First, compile your source code into ocaml bytecode :
 ```
 ocamlfind ocamlc -o example.byte -no-check-prims -package js_of_ocaml,gen_js_api,ocaml-googlemaps -linkpkg example.ml
@@ -42,12 +42,12 @@ The conventions used are ```gen_js_api``` 's :
     * ```create``` : which creates the object. Its parameters are all labelled by fields name
     * ```foofield``` : a getter for the field called ```foofield```
     * ```set_foofield``` : a setter for the field called ```foofield```
- 
+
 **WARNING** : Some objects in Google Map API contain a field called ```type```. As ```type``` is a keyword in OCaml, you need to use ```type'```
 
 Example in Javascript :
 ```javascript
-var opts = 
+var opts =
   {
     center: {lat: -34.397, lng: 150.644},
     zoom: 10
@@ -66,7 +66,13 @@ let map = Map.new_map maps opts ()
 ```
 Here, as the last arguments of ```create``` and ```new_map``` are optional, we also need to give ```()```
 
-### Version used : 
+### MarkerClusterer
+
+The `2.4` version added a `MarkerClusterer` module into `Googlemap`: a
+module that do a binding to the [MarkerClusterer
+plugin](https://github.com/plank/MarkerClusterer).
+
+### Version used :
 This binding is using Google Map v3.24
 
 ### Known bugs:

--- a/googlemaps.mli
+++ b/googlemaps.mli
@@ -3754,3 +3754,61 @@ module Poly: sig
 end
 [@js.scope "google.maps.geometry.poly"]
 (* End Namespaces *)
+
+(*MarkerClusterer:*)
+type mc (*the MarkerClusterer type*)
+
+val t : unit -> mc [@@js.get "MarkerClusterer"]
+
+(*val t_v2 : unit -> mc [@@js.get "window.MarkerClusterer"]*)
+
+(*a MarkerClusterer element*)
+[@@@js.stop]
+
+type mc_elt = mc Js_of_ocaml.Js.t
+
+[@@@js.start]
+
+[@@@js.implem type mc_elt = mc Js_of_ocaml.Js.t]
+
+[@@@js.implem let mc_elt_of_js = Obj.magic]
+
+[@@@js.implem let mc_elt_to_js = Obj.magic]
+
+module MarkerClusterer : sig
+  type styles
+
+  val styles :
+    ?url:string ->
+    ?height:int ->
+    ?width:int ->
+    ?anchor:int array ->
+    ?text_color:string ->
+    ?text_size:int ->
+    unit ->
+    styles
+      [@@js.builder] [@@js.verbatim_names]
+
+  type opts
+
+  val opts :
+    ?grid_size:int ->
+    ?max_zoom:int ->
+    ?zoom_on_click:bool ->
+    ?info_on_click:bool ->
+    ?info_on_click_zoom:int ->
+    ?styles:styles ->
+    unit ->
+    opts
+      [@@js.builder] [@@js.verbatim_names]
+
+  val new_marker_clusterer :
+    Map.t -> ?opt_markers:Marker.t -> ?opt_options:opts -> unit -> mc_elt
+    [@@js.new]
+
+  val set_max_zoom : mc_elt -> int -> unit [@@js.call "setMaxZoom"]
+
+  val add_marker : mc_elt -> Marker.t -> ?opt_nodraw:bool -> unit -> unit
+    [@@js.call "addMarker"]
+end
+[@js.scope "MarkerClusterer"]

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "ocaml-googlemaps"
-version: "2.3"
+version: "2.4"
 maintainer: "o-marshmallow"
 authors: "o-marshmallow"
 homepage: "https://github.com/besport/ocaml-googlemaps"


### PR DESCRIPTION
This new module will be used to removes `Js.Unsafe.global` of `MarkerClusterer` into bs